### PR TITLE
feat: migrar autenticación del frontend de Basic Auth a JWT

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,14 +1,32 @@
 const BASE = import.meta.env.VITE_API_BASE || "/api"
 
-// credenciales básicas codificadas en Base64
-const AUTH = "Basic " + btoa("house:house123")
+function getToken() {
+  return sessionStorage.getItem("token")
+}
+
+function authHeaders() {
+  const token = getToken()
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+export async function login(usuario, password) {
+  const res = await fetch(`${BASE}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ usuario, password })
+  })
+  if (res.status === 401) return null
+  if (!res.ok) throw new Error("Error en login")
+  const data = await res.json()
+  return data.token
+}
 
 export async function listarEnfermedades(q) {
   const url = q
     ? `${BASE}/enfermedades?q=${encodeURIComponent(q)}`
     : `${BASE}/enfermedades`
   const res = await fetch(url, {
-    headers: { Authorization: AUTH }
+    headers: authHeaders()
   })
   if (!res.ok) throw new Error("Error listando enfermedades")
   return res.json()
@@ -16,7 +34,7 @@ export async function listarEnfermedades(q) {
 
 export async function getEnfermedad(nombre) {
   const res = await fetch(`${BASE}/enfermedades/${encodeURIComponent(nombre)}`, {
-    headers: { Authorization: AUTH }
+    headers: authHeaders()
   })
   if (res.status === 404) return null
   if (!res.ok) throw new Error("Error obteniendo enfermedad")
@@ -25,19 +43,8 @@ export async function getEnfermedad(nombre) {
 
 export async function listarSintomas(nombre) {
   const res = await fetch(`${BASE}/enfermedades/${encodeURIComponent(nombre)}/sintomas`, {
-    headers: { Authorization: AUTH }
+    headers: authHeaders()
   })
   if (!res.ok) throw new Error("Error listando síntomas")
   return res.json()
-}
-
-// esta función ya no inventa un endpoint, simplemente comprueba credenciales
-export async function loginBasic(usuario, password) {
-  const token = "Basic " + btoa(`${usuario}:${password}`)
-  const res = await fetch(`${BASE}/enfermedades`, {
-    headers: { Authorization: token }
-  })
-  if (res.status === 401) return null
-  if (!res.ok) throw new Error("Error en login")
-  return true // devolvemos true si las credenciales sirven
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { loginBasic } from "../api";
+import { login } from "../api";
 import { useNavigate, useLocation } from "react-router-dom";
 import Button from "../components/ui/Button.jsx";
 import TextInput from "../components/ui/TextInput.jsx";
@@ -18,19 +18,13 @@ export default function Login() {
     setError("");
     setLoading(true);
     try {
-      const data = await loginBasic(usuario, password);
-      if (!data) {
+      const token = await login(usuario, password);
+      if (!token) {
         setError("Credenciales inválidas");
         return;
       }
-      const safeAuth = {
-        tipo: data.tipo,
-        usuario: {
-          nombre: data.usuario?.nombre,
-          usuario: data.usuario?.usuario,
-        },
-      };
-      sessionStorage.setItem("auth", JSON.stringify(safeAuth));
+      sessionStorage.setItem("token", token);
+      sessionStorage.setItem("usuario", usuario);
 
       const from = location.state?.from;
       const to = from


### PR DESCRIPTION
Closes #6

- Reescrito api.js para usar JWT en lugar de Basic Auth
- Login.jsx actualizado para guardar el token en sessionStorage
- Eliminadas credenciales hardcodeadas del frontend