### PR TITLE
feat: filtrar enfermedades por síntoma

### DIFF
--- a/backend/src/main/java/api/EnfermedadController.java
+++ b/backend/src/main/java/api/EnfermedadController.java
@@ -43,7 +43,11 @@ public class EnfermedadController {
     public ResponseEntity<Page<Enfermedad>> listar(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(required = false) String nivelRiesgo) {
+            @RequestParam(required = false) String nivelRiesgo,
+            @RequestParam(required = false) UUID sintomaId) {
+        if (sintomaId != null) {
+            return ResponseEntity.ok(enfService.filtrarPorSintoma(sintomaId, page, size));
+        }
         if (nivelRiesgo != null) {
             return ResponseEntity.ok(enfService.filtrarPorNivelRiesgo(nivelRiesgo, page, size));
         }

--- a/backend/src/main/java/api/repository/EnfermedadRepository.java
+++ b/backend/src/main/java/api/repository/EnfermedadRepository.java
@@ -16,4 +16,5 @@ public interface EnfermedadRepository extends JpaRepository<Enfermedad, UUID> {
     @EntityGraph(attributePaths = "sintomas")
     Optional<Enfermedad> findWithSintomasByNombreIgnoreCase(String nombre);
     Page<Enfermedad> findByNivelRiesgo(String nivelRiesgo, Pageable pageable);
+    Page<Enfermedad> findBySintomasId(UUID sintomaId, Pageable pageable);
 }

--- a/backend/src/main/java/api/service/EnfermedadService.java
+++ b/backend/src/main/java/api/service/EnfermedadService.java
@@ -41,6 +41,11 @@ public class EnfermedadService {
     }
 
     @Transactional(readOnly = true)
+    public Page<Enfermedad> filtrarPorSintoma(UUID sintomaId, int page, int size) {
+        return enfermedadRepository.findBySintomasId(sintomaId, PageRequest.of(page, size));
+    }
+
+    @Transactional(readOnly = true)
     public List<Enfermedad> listar() {
         List<Enfermedad> result = new ArrayList<>();
         enfermedadRepository.findAll().forEach(result::add);


### PR DESCRIPTION
Closes #11

- Añadido parámetro opcional sintomaId al endpoint GET /api/enfermedades
- Ejemplo: GET /api/enfermedades?sintomaId={uuid}
- Compatible con paginación y con el filtro de nivel de riesgo