### PR TITLE
feat: CRUD de usuarios para rol ADMIN

### DIFF
--- a/backend/src/main/java/api/UsuarioController.java
+++ b/backend/src/main/java/api/UsuarioController.java
@@ -3,14 +3,17 @@ package api;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import api.dto.CambioPasswordDTO;
 import api.model.Usuario;
@@ -39,6 +42,27 @@ public class UsuarioController {
         return usuarioRepository.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Usuario> actualizar(@PathVariable UUID id, @RequestBody Usuario datos) {
+        Usuario usuario = usuarioRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado"));
+        usuario.setNombre(datos.getNombre());
+        usuario.setRol(datos.getRol());
+        usuario.setEnabled(datos.isEnabled());
+        return ResponseEntity.ok(usuarioRepository.save(usuario));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable UUID id, Authentication auth) {
+        Usuario usuario = usuarioRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado"));
+        if (usuario.getUsuario().equals(auth.getName())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No puedes eliminarte a ti mismo");
+        }
+        usuarioRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
     }
 
     @PutMapping("/me/password")


### PR DESCRIPTION
Closes #17

- Añadidos endpoints PUT /api/usuarios/{id} y DELETE /api/usuarios/{id}
- Un usuario no puede eliminarse a sí mismo (devuelve 403)
- Permite actualizar nombre, rol y estado enabled