### PR TITLE
feat: buscar enfermedades por nombre parcial

### DIFF
--- a/backend/src/main/java/api/repository/EnfermedadRepository.java
+++ b/backend/src/main/java/api/repository/EnfermedadRepository.java
@@ -17,4 +17,5 @@ public interface EnfermedadRepository extends JpaRepository<Enfermedad, UUID> {
     Optional<Enfermedad> findWithSintomasByNombreIgnoreCase(String nombre);
     Page<Enfermedad> findByNivelRiesgo(String nivelRiesgo, Pageable pageable);
     Page<Enfermedad> findBySintomasId(UUID sintomaId, Pageable pageable);
+    Page<Enfermedad> findByNombreContainingIgnoreCase(String nombre, Pageable pageable);
 }

--- a/backend/src/main/java/api/service/EnfermedadService.java
+++ b/backend/src/main/java/api/service/EnfermedadService.java
@@ -91,4 +91,9 @@ public class EnfermedadService {
         }
         return existed; // true -> 204, false -> 404
     }
+
+    @Transactional(readOnly = true)
+    public Page<Enfermedad> buscarPorNombre(String nombre, int page, int size) {
+        return enfermedadRepository.findByNombreContainingIgnoreCase(nombre, PageRequest.of(page, size));
+    }
 }

--- a/backend/src/main/java/api/web/EnfermedadController.java
+++ b/backend/src/main/java/api/web/EnfermedadController.java
@@ -44,7 +44,11 @@ public class EnfermedadController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String nivelRiesgo,
-            @RequestParam(required = false) UUID sintomaId) {
+            @RequestParam(required = false) UUID sintomaId,
+            @RequestParam(required = false) String nombre) {
+        if (nombre != null && !nombre.isBlank()) {
+            return ResponseEntity.ok(enfService.buscarPorNombre(nombre, page, size));
+        }
         if (sintomaId != null) {
             return ResponseEntity.ok(enfService.filtrarPorSintoma(sintomaId, page, size));
         }


### PR DESCRIPTION
Closes #23

- Añadido parámetro opcional nombre al endpoint GET /api/enfermedades
- Búsqueda parcial e insensible a mayúsculas usando ILIKE de JPA
- Ejemplo: GET /api/enfermedades?nombre=diab
- Compatible con paginación